### PR TITLE
There is a bug for guard-spork in ubuntu

### DIFF
--- a/static-pages.html
+++ b/static-pages.html
@@ -1870,7 +1870,7 @@ bundler_stubs/
 <div class="code"><div class="highlight"><pre><span class="c1"># Test gems on Linux</span>
 <span class="n">group</span> <span class="ss">:test</span> <span class="k">do</span>
   <span class="n">gem</span> <span class="s1">&#39;capybara&#39;</span><span class="p">,</span> <span class="s1">&#39;1.1.2&#39;</span>
-  <span class="n">gem</span> <span class="s1">&#39;rb-inotify&#39;</span><span class="p">,</span> <span class="s1">&#39;0.8.8&#39;</span>
+  <span class="n">gem</span> <span class="s1">&#39;rb-inotify&#39;</span><span class="p">,</span> <span class="s1">&#39;0.9.0&#39;</span>
   <span class="n">gem</span> <span class="s1">&#39;libnotify&#39;</span><span class="p">,</span> <span class="s1">&#39;0.5.9&#39;</span>
 <span class="k">end</span> 
 </pre></div>
@@ -1988,7 +1988,7 @@ bundler_stubs/
   <span class="o">.</span>
   <span class="o">.</span>
   <span class="o">.</span>
-  <span class="n">gem</span> <span class="s1">&#39;guard-spork&#39;</span><span class="p">,</span> <span class="s1">&#39;1.2.0&#39;</span>
+  <span class="n">gem</span> <span class="s1">&#39;guard-spork&#39;</span><span class="p">,</span> <span class="s1">&#39;1.5.0&#39;</span>
   <span class="n">gem</span> <span class="s1">&#39;spork&#39;</span><span class="p">,</span> <span class="s1">&#39;0.9.2&#39;</span>
 <span class="k">end</span>
 <span class="o">.</span>

--- a/updating-showing-and-deleting-users.html
+++ b/updating-showing-and-deleting-users.html
@@ -2227,7 +2227,7 @@ code appears in <a class="ref" href="updating-showing-and-deleting-users.html#co
   <span class="n">gem</span> <span class="s1">&#39;sqlite3&#39;</span><span class="p">,</span> <span class="s1">&#39;1.3.5&#39;</span>
   <span class="n">gem</span> <span class="s1">&#39;rspec-rails&#39;</span><span class="p">,</span> <span class="s1">&#39;2.11.0&#39;</span>
   <span class="c1"># gem &#39;guard-rspec&#39;, &#39;1.2.1&#39;</span>
-  <span class="c1"># gem &#39;guard-spork&#39;, &#39;1.2.0&#39;  </span>
+  <span class="c1"># gem &#39;guard-spork&#39;, &#39;1.5.0&#39;  </span>
   <span class="c1"># gem &#39;spork&#39;, &#39;0.9.2&#39;</span>
 <span class="k">end</span>
 


### PR DESCRIPTION
Hi Michael,

I run the tool guard and spork in ubuntu 12.10 as your book said. the guard can't start spork automatically and show some error infomation about launch process.

I update gem guard-spork version from 1.2.0 to 1.5.0, then it can work.  Because there is a warning information about gem rb-inotify, I update it's version from 0.8.8 to 0.9.0. Now, it can work well.

Best regards,
Glitter 
